### PR TITLE
fix decimal exception

### DIFF
--- a/src/lambda/lambda_github_put.py
+++ b/src/lambda/lambda_github_put.py
@@ -63,5 +63,5 @@ def validate_event(event_body):
 def languages_to_decimal_type(languages):
     dec_languages = {}
     for lang in languages:
-        dec_languages[lang] = Decimal(languages[lang])
+        dec_languages[lang] = Decimal(str(languages[lang]))
     return dec_languages


### PR DESCRIPTION
Decimal exceptions were causing while parsing the decimal percentage values in the languages object.

Example: languages {
"python": 50.456,
"java": 49.544
}
